### PR TITLE
Added support for "DocumentName" fax parameter to native Windows code.

### DIFF
--- a/src/main/native/windows/dll/fax4j.cpp
+++ b/src/main/native/windows/dll/fax4j.cpp
@@ -329,7 +329,7 @@ Response getFaxJobStatus(LPCTSTR serverName,DWORD faxJobID)
  * 			The file to fax
  * @return	The response object
  */
-FAX4J_API Response submitFaxJobNative(LPCTSTR serverName,LPCTSTR targetAddress,LPCTSTR targetName,LPCTSTR senderName,LPCTSTR fileName)
+FAX4J_API Response submitFaxJobNative(LPCTSTR serverName,LPCTSTR targetAddress,LPCTSTR targetName,LPCTSTR senderName,LPCTSTR fileName,LPCTSTR documentName)
 {
 	logDebug("Invoking submitFaxJobNative");
 
@@ -400,6 +400,7 @@ FAX4J_API Response submitFaxJobNative(LPCTSTR serverName,LPCTSTR targetAddress,L
 	faxJobParameters->SenderName=senderName;
 	faxJobParameters->ScheduleAction=JSA_NOW;
 	faxJobParameters->DeliveryReportType=DRT_NONE;
+	faxJobParameters->DocumentName=documentName;
 
 	//send fax
 	DWORD faxJobID;
@@ -563,7 +564,7 @@ FAX4J_API char* getLastErrorMessageDLL()
  * 			The file to fax
  * @return	The fax job ID (null in case of an error)
  */
-FAX4J_API DWORD submitFaxJobDLL(char* serverName,char* targetAddress,char* targetName,char* senderName,char* fileName)
+FAX4J_API DWORD submitFaxJobDLL(char* serverName,char* targetAddress,char* targetName,char* senderName,char* fileName,char* documentName)
 {
 	//get values
 	LPCTSTR serverNameStr=NULL;
@@ -571,6 +572,7 @@ FAX4J_API DWORD submitFaxJobDLL(char* serverName,char* targetAddress,char* targe
 	LPCTSTR targetNameStr=NULL;
 	LPCTSTR senderNameStr=NULL;
 	LPCTSTR fileNameStr=NULL;
+	LPCTSTR documentNameStr=NULL;
 	if(serverName!=NULL)
 	{
 		serverNameStr=convertCharArrayToLPCTSTR(serverName);
@@ -591,9 +593,13 @@ FAX4J_API DWORD submitFaxJobDLL(char* serverName,char* targetAddress,char* targe
 	{
 		fileNameStr=convertCharArrayToLPCTSTR(fileName);
 	}
+	if(documentName!=NULL)
+	{
+		documentNameStr=convertCharArrayToLPCTSTR(documentName);
+	}
 
 	//invoke fax action
-	Response response=submitFaxJobNative(serverNameStr,targetAddressStr,targetNameStr,senderNameStr,fileNameStr);
+	Response response=submitFaxJobNative(serverNameStr,targetAddressStr,targetNameStr,senderNameStr,fileNameStr,documentNameStr);
 	
 	//get output
 	DWORD faxJobID=0;
@@ -721,6 +727,7 @@ FAX4J_API int runCLI(int argc,const char* argv[])
 	char* targetName=NULL;
 	char* senderName=NULL;
 	char* fileName=NULL;
+	char* documentName=NULL;
 
 	bool donePrinted=false;
 	if(argc>1)
@@ -766,6 +773,10 @@ FAX4J_API int runCLI(int argc,const char* argv[])
 			{
 				fileName=value;
 			}
+			else if (strcmp(argument,"-document")==0)
+			{
+				documentName=value;
+			}
 		}
 		
 		logDebug("Read input:");
@@ -783,6 +794,8 @@ FAX4J_API int runCLI(int argc,const char* argv[])
 		logDebug(senderName);
 		logDebug("File:");
 		logDebug(fileName);
+		logDebug("Document:");
+		logDebug(documentName);
 
 		if(actionType!=NULL)
 		{
@@ -792,7 +805,7 @@ FAX4J_API int runCLI(int argc,const char* argv[])
 			if(strcmp(actionType,"submit")==0)
 			{
 				//invoke fax action
-				faxJobID=submitFaxJobDLL(server,targetAddress,targetName,senderName,fileName);
+				faxJobID=submitFaxJobDLL(server,targetAddress,targetName,senderName,fileName,documentName);
 			}
 			else if(strcmp(actionType,"suspend")==0)
 			{

--- a/src/main/native/windows/dll/fax4j.h
+++ b/src/main/native/windows/dll/fax4j.h
@@ -105,7 +105,7 @@ FAX4J_API LPCTSTR convertCharArrayToLPCTSTR(char* text);
  * 			The file to fax
  * @return	The fax job ID (null in case of an error)
  */
-FAX4J_API Response submitFaxJobNative(LPCTSTR serverName,LPCTSTR targetAddress,LPCTSTR targetName,LPCTSTR senderName,LPCTSTR fileName);
+FAX4J_API Response submitFaxJobNative(LPCTSTR serverName,LPCTSTR targetAddress,LPCTSTR targetName,LPCTSTR senderName,LPCTSTR fileName,LPCTSTR documentName);
 
 /**
  * This function will suspend an existing fax job.


### PR DESCRIPTION
Had a need to use the DocumentName parameter supported by FAX_JOB_PARAM. Added such support to the native Windows code. Might be useful to others if they rely on what's in Windows Faxing's OutboxLOG.txt.