### PR TITLE
Added support for "DocumentName" fax parameter on Windows.

### DIFF
--- a/src/main/native/windows/dll/fax4j.cpp
+++ b/src/main/native/windows/dll/fax4j.cpp
@@ -329,7 +329,7 @@ Response getFaxJobStatus(LPCTSTR serverName,DWORD faxJobID)
  * 			The file to fax
  * @return	The response object
  */
-FAX4J_API Response submitFaxJobNative(LPCTSTR serverName,LPCTSTR targetAddress,LPCTSTR targetName,LPCTSTR senderName,LPCTSTR fileName)
+FAX4J_API Response submitFaxJobNative(LPCTSTR serverName,LPCTSTR targetAddress,LPCTSTR targetName,LPCTSTR senderName,LPCTSTR fileName,LPCTSTR documentName)
 {
 	logDebug("Invoking submitFaxJobNative");
 
@@ -400,6 +400,7 @@ FAX4J_API Response submitFaxJobNative(LPCTSTR serverName,LPCTSTR targetAddress,L
 	faxJobParameters->SenderName=senderName;
 	faxJobParameters->ScheduleAction=JSA_NOW;
 	faxJobParameters->DeliveryReportType=DRT_NONE;
+	faxJobParameters->DocumentName=documentName;
 
 	//send fax
 	DWORD faxJobID;
@@ -563,7 +564,7 @@ FAX4J_API char* getLastErrorMessageDLL()
  * 			The file to fax
  * @return	The fax job ID (null in case of an error)
  */
-FAX4J_API DWORD submitFaxJobDLL(char* serverName,char* targetAddress,char* targetName,char* senderName,char* fileName)
+FAX4J_API DWORD submitFaxJobDLL(char* serverName,char* targetAddress,char* targetName,char* senderName,char* fileName,char* documentName)
 {
 	//get values
 	LPCTSTR serverNameStr=NULL;
@@ -571,6 +572,7 @@ FAX4J_API DWORD submitFaxJobDLL(char* serverName,char* targetAddress,char* targe
 	LPCTSTR targetNameStr=NULL;
 	LPCTSTR senderNameStr=NULL;
 	LPCTSTR fileNameStr=NULL;
+	LPCTSTR documentNameStr=NULL;
 	if(serverName!=NULL)
 	{
 		serverNameStr=convertCharArrayToLPCTSTR(serverName);
@@ -591,9 +593,13 @@ FAX4J_API DWORD submitFaxJobDLL(char* serverName,char* targetAddress,char* targe
 	{
 		fileNameStr=convertCharArrayToLPCTSTR(fileName);
 	}
+	if(documentName!=NULL)
+	{
+		documentNameStr=convertCharArrayToLPCTSTR(documentName);
+	}
 
 	//invoke fax action
-	Response response=submitFaxJobNative(serverNameStr,targetAddressStr,targetNameStr,senderNameStr,fileNameStr);
+	Response response=submitFaxJobNative(serverNameStr,targetAddressStr,targetNameStr,senderNameStr,fileNameStr,documentNameStr);
 	
 	//get output
 	DWORD faxJobID=0;
@@ -721,6 +727,7 @@ FAX4J_API int runCLI(int argc,const char* argv[])
 	char* targetName=NULL;
 	char* senderName=NULL;
 	char* fileName=NULL;
+	char* documentName=NULL;
 
 	bool donePrinted=false;
 	if(argc>1)
@@ -766,6 +773,10 @@ FAX4J_API int runCLI(int argc,const char* argv[])
 			{
 				fileName=value;
 			}
+			else if (strcmp(argument,"-document")==0)
+			{
+				documentName=value;
+			}
 		}
 		
 		logDebug("Read input:");
@@ -783,6 +794,8 @@ FAX4J_API int runCLI(int argc,const char* argv[])
 		logDebug(senderName);
 		logDebug("File:");
 		logDebug(fileName);
+		logDebug("Document:");
+		logDebug(documentName);
 
 		if(actionType!=NULL)
 		{
@@ -792,7 +805,7 @@ FAX4J_API int runCLI(int argc,const char* argv[])
 			if(strcmp(actionType,"submit")==0)
 			{
 				//invoke fax action
-				faxJobID=submitFaxJobDLL(server,targetAddress,targetName,senderName,fileName);
+				faxJobID=submitFaxJobDLL(server,targetAddress,targetName,senderName,fileName,documentName);
 			}
 			else if(strcmp(actionType,"suspend")==0)
 			{

--- a/src/main/native/windows/dll/fax4j.h
+++ b/src/main/native/windows/dll/fax4j.h
@@ -105,7 +105,7 @@ FAX4J_API LPCTSTR convertCharArrayToLPCTSTR(char* text);
  * 			The file to fax
  * @return	The fax job ID (null in case of an error)
  */
-FAX4J_API Response submitFaxJobNative(LPCTSTR serverName,LPCTSTR targetAddress,LPCTSTR targetName,LPCTSTR senderName,LPCTSTR fileName);
+FAX4J_API Response submitFaxJobNative(LPCTSTR serverName,LPCTSTR targetAddress,LPCTSTR targetName,LPCTSTR senderName,LPCTSTR fileName,LPCTSTR documentName);
 
 /**
  * This function will suspend an existing fax job.

--- a/src/main/native/windows/dll/org_fax4j_spi_windows_WindowsJNIFaxClientSpi.cpp
+++ b/src/main/native/windows/dll/org_fax4j_spi_windows_WindowsJNIFaxClientSpi.cpp
@@ -160,7 +160,7 @@ JNIEXPORT void JNICALL Java_org_fax4j_spi_windows_WindowsJNIFaxClientSpi_setDebu
  * 			The file to fax
  * @return	The fax job ID (null in case of an error)
  */
-JNIEXPORT jint JNICALL Java_org_fax4j_spi_windows_WindowsJNIFaxClientSpi_submitFaxJobNative(JNIEnv* jniEnv,jclass classDefinition,jstring serverName,jstring targetAddress,jstring targetName,jstring senderName,jstring fileName)
+JNIEXPORT jint JNICALL Java_org_fax4j_spi_windows_WindowsJNIFaxClientSpi_submitFaxJobNative(JNIEnv* jniEnv,jclass classDefinition,jstring serverName,jstring targetAddress,jstring targetName,jstring senderName,jstring fileName,jstring documentName)
 {
 	logDebug("Invoking JNI submitFaxJobNative");
 
@@ -176,9 +176,11 @@ JNIEXPORT jint JNICALL Java_org_fax4j_spi_windows_WindowsJNIFaxClientSpi_submitF
 	LPCTSTR cSenderName=convertToStr(cConstSenderName);
 	const char* cConstFileName=getString(jniEnv,fileName);
 	LPCTSTR cFileName=convertToStr(cConstFileName);
+	const char* cConstDocumentName=getString(jniEnv,documentName);
+	LPCTSTR cDocumentName=convertToStr(cConstDocumentName);
 
 	//submit fax job
-	Response response=submitFaxJobNative(cServerName,cTargetAddress,cTargetName,cSenderName,cFileName);
+	Response response=submitFaxJobNative(cServerName,cTargetAddress,cTargetName,cSenderName,cFileName,cDocumentName);
 
 	logDebug("Releasing jni data types.");
 	releaseString(jniEnv,serverName,cConstServerName);
@@ -186,6 +188,7 @@ JNIEXPORT jint JNICALL Java_org_fax4j_spi_windows_WindowsJNIFaxClientSpi_submitF
 	releaseString(jniEnv,targetName,cConstTargetName);
 	releaseString(jniEnv,senderName,cConstSenderName);
 	releaseString(jniEnv,fileName,cConstFileName);
+	releaseString(jniEnv,documentName,cConstDocumentName);
 
 	jint faxJobID=0;
 	if(response.result)


### PR DESCRIPTION
Retrying a pull request I attempted before. All but one test passed. The following test did not complete:

nativeFlowViaJNITest in WindowsFaxClientSpiTest.java

It received an "UnsatisfiedLinkError" exception. I am unclear on why this is the case, but I may just have an unusual environment. Everything else checks out and the change does work correctly. (Tested on both Windows XP and Windows 10.)